### PR TITLE
Add centralized badge catalogue page for gamification achievements

### DIFF
--- a/app/gamification/routes.py
+++ b/app/gamification/routes.py
@@ -1,12 +1,40 @@
 from flask import Blueprint, render_template
 from sqlalchemy import func
 from app import db
-
 from app.models import User
 from app.models import Review
 from app.models import Restaurant
 
 bp = Blueprint('gamification', __name__)
+bp = Blueprint('gamification', __name__)
+
+BADGE_REQUIREMENTS = {
+
+    "FIRST_BITE": {
+        'title': 'First Bite',
+        'description': 'Write your first review.'
+    },
+
+    "EXPLORER": {
+        'title': 'Explorer',
+        'description': 'Review restaurants across multiple suburbs.'
+    },
+
+    "CRITIC": {
+        'title': 'Critic',
+        'description': 'Earn high writing XP.'
+    },
+}
+
+
+@bp.route('/badges')
+def badges():
+
+    return render_template(
+        'gamification/badges.html',
+
+        badges=BADGE_REQUIREMENTS
+    )
 
 @bp.route('/leaderboard')
 def leaderboard():

--- a/app/gamification/routes.py
+++ b/app/gamification/routes.py
@@ -1,40 +1,12 @@
 from flask import Blueprint, render_template
 from sqlalchemy import func
+from app.gamification.badges import BADGES
 from app import db
 from app.models import User
 from app.models import Review
 from app.models import Restaurant
 
 bp = Blueprint('gamification', __name__)
-bp = Blueprint('gamification', __name__)
-
-BADGE_REQUIREMENTS = {
-
-    "FIRST_BITE": {
-        'title': 'First Bite',
-        'description': 'Write your first review.'
-    },
-
-    "EXPLORER": {
-        'title': 'Explorer',
-        'description': 'Review restaurants across multiple suburbs.'
-    },
-
-    "CRITIC": {
-        'title': 'Critic',
-        'description': 'Earn high writing XP.'
-    },
-}
-
-
-@bp.route('/badges')
-def badges():
-
-    return render_template(
-        'gamification/badges.html',
-
-        badges=BADGE_REQUIREMENTS
-    )
 
 @bp.route('/leaderboard')
 def leaderboard():
@@ -110,3 +82,12 @@ def leaderboard():
         suburb_labels=suburb_labels,
         suburb_counts=suburb_counts,
     )
+    
+@bp.route('/badges')
+def badges():
+
+    return render_template(
+        'gamification/badges.html',
+
+        badges=BADGES
+    )       

--- a/app/social/routes.py
+++ b/app/social/routes.py
@@ -2,6 +2,7 @@ from flask import Blueprint, abort, flash, jsonify, redirect, render_template, u
 from flask_login import current_user, login_required
 from sqlalchemy import func
 
+
 from app import db
 from app.gamification.badges import badge_cards_for
 from app.gamification.logic import level_for_xp
@@ -16,6 +17,7 @@ def _find_user(username):
     ).first()
 
 bp = Blueprint('social', __name__)
+
 
 @bp.route('/profile/<username>')
 def profile(username):

--- a/app/templates/gamification/badges.html
+++ b/app/templates/gamification/badges.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block title %}
+Badge Catalogue — RateFoodPerth
+{% endblock %}
+
+{% block content %}
+
+<section class="hero-section">
+    <div class="container py-5">
+
+        <h1 class="hero-headline mb-2">
+            Badge Catalogue<span class="logo-dot">.</span>
+        </h1>
+
+        <p class="hero-subtext mb-0">
+            Discover every achievement available across the RateFoodPerth community.
+        </p>
+
+    </div>
+</section>
+
+<div class="feed-wrapper">
+
+    <div class="container py-5">
+
+        <div class="row g-4">
+
+            {% for badge, info in badges.items() %}
+
+            <div class="col-md-4">
+
+                <div class="card shadow-sm border-0 rounded-4 h-100">
+
+                    <div class="card-body p-4 text-center">
+
+                        <div class="mb-3">
+
+                            <i
+                                class="bi bi-award-fill text-warning"
+                                style="font-size: 3rem;"
+                            ></i>
+
+                        </div>
+
+                        <h3 class="fw-bold mb-3">
+
+                            {{ info.title }}
+
+                        </h3>
+
+                        <p class="text-muted mb-0">
+
+                            {{ info.description }}
+
+                        </p>
+
+                    </div>
+
+                </div>
+
+            </div>
+
+            {% endfor %}
+
+        </div>
+
+    </div>
+
+</div>
+
+{% endblock %}

--- a/app/templates/gamification/badges.html
+++ b/app/templates/gamification/badges.html
@@ -37,7 +37,7 @@ Badge Catalogue — RateFoodPerth
                         <div class="mb-3">
 
                             <i
-                                class="bi bi-award-fill text-warning"
+                                class="bi {{ info.icon }} {{ info.colour_class }}"
                                 style="font-size: 3rem;"
                             ></i>
 
@@ -45,13 +45,20 @@ Badge Catalogue — RateFoodPerth
 
                         <h3 class="fw-bold mb-3">
 
-                            {{ info.title }}
+                            {{ info.label }}
 
                         </h3>
 
-                        <p class="text-muted mb-0">
+                        <p class="text-muted mb-3">
 
                             {{ info.description }}
+
+                        </p>
+                        
+                        <p class="fw-semibold mb-0">
+
+                            Requirement:
+                            {{ info.threshold }}
 
                         </p>
 


### PR DESCRIPTION
 Overview:

This pull request introduces a dedicated badge catalogue page that displays all available gamification achievements and their corresponding unlock requirements using the project’s centralized badge metadata registry.

 Changes Made:

### Badge Catalogue Page

* Added `/badges` route for viewing all available achievements
* Added dedicated `badges.html` gamification template
* Implemented responsive Bootstrap-based badge card layout
* Added badge icons, descriptions, and unlock thresholds

### Centralized Gamification Integration

* Integrated the page with the existing shared `BADGES` registry
* Reused centralized badge metadata instead of duplicating badge definitions
* Added dynamic rendering for:

  * badge labels
  * descriptions
  * icons
  * colour classes
  * achievement requirements

### Badge Coverage

The catalogue now displays all implemented badges including:

* First Bite
* Pen & Fork
* Suburb Scout
* On Fire
* Ruthlessly Accurate
* Globe Trotter

### Architecture Improvements

* Preserved a single source of truth for badge metadata
* Ensured future badge additions automatically propagate to the catalogue page
* Kept gamification rendering consistent with existing profile and award systems

## Testing

* Verified `/badges` route renders successfully
* Verified all implemented badges display correctly
* Verified icons and colour classes render dynamically
* Verified achievement thresholds and descriptions match gamification logic
* Verified responsive card layout works correctly across the page

## Result

The application now includes a centralized badge catalogue system that clearly communicates all available achievements, progression goals, and gamification milestones to users while remaining fully synchronized with the shared badge award infrastructure.
